### PR TITLE
refine calendar page design

### DIFF
--- a/components/NavaCalendar.tsx
+++ b/components/NavaCalendar.tsx
@@ -61,19 +61,19 @@ const NavaCalendar: React.FC<NavaCalendarProps> = ({ events }) => {
 
     return (
         <div className="flex h-full">
-            <YearNavigator 
+            <YearNavigator
                 events={events}
                 currentDate={currentDate}
                 onDateSelect={setCurrentDate}
             />
             <div className="flex-1 flex flex-col min-w-0">
-                <header className="flex-shrink-0 flex flex-col md:flex-row justify-between items-start md:items-center p-4 gap-4 border-b border-slate-200">
+                <header className="flex-shrink-0 flex flex-col md:flex-row justify-between items-start md:items-center p-4 gap-4 bg-white/80 backdrop-blur-sm border-b border-slate-200 shadow-sm">
                     <h2 className="text-xl font-bold text-text-primary">NAVA Operational Calendar</h2>
                     <Legend activeFilters={activeFilters} onToggle={handleToggleFilter} />
                 </header>
-                <main className="flex-grow p-4 min-h-0 bg-slate-50">
-                    <GridView 
-                        events={filteredEvents} 
+                <main className="flex-grow p-4 min-h-0 bg-bg-panel-hover">
+                    <GridView
+                        events={filteredEvents}
                         currentDate={currentDate}
                         setCurrentDate={setCurrentDate}
                     />

--- a/components/YearlyCalendarView.tsx
+++ b/components/YearlyCalendarView.tsx
@@ -43,13 +43,13 @@ const YearlyCalendarView: React.FC<{ events: CalendarEvent[] }> = ({ events }) =
 
 
     return (
-        <div className="h-full flex flex-col bg-slate-50 relative">
-            <header className="flex-shrink-0 flex justify-center items-center p-3 gap-4">
+        <div className="h-full flex flex-col bg-bg-panel relative">
+            <header className="flex-shrink-0 flex justify-center items-center p-3 gap-4 bg-white/80 backdrop-blur-sm border-b border-slate-200 shadow-sm">
                  <div className="flex items-center bg-white border border-slate-300 rounded-lg shadow-sm overflow-hidden">
                     <span className="px-3 py-2 text-sm font-bold text-green-800 bg-green-200">Academic Year</span>
-                     <select 
-                        value={academicYear} 
-                        onChange={e => setAcademicYear(e.target.value)} 
+                     <select
+                        value={academicYear}
+                        onChange={e => setAcademicYear(e.target.value)}
                         className="font-bold text-lg text-text-primary bg-transparent pl-3 pr-4 py-1.5 focus:outline-none appearance-none cursor-pointer"
                     >
                         {ACADEMIC_YEARS.map(year => (
@@ -59,7 +59,7 @@ const YearlyCalendarView: React.FC<{ events: CalendarEvent[] }> = ({ events }) =
                 </div>
             </header>
 
-            <div className="flex-grow min-h-0 overflow-auto p-2">
+            <div className="flex-grow min-h-0 overflow-auto p-2 bg-bg-panel-hover">
                 <table className="w-full border-collapse">
                     <thead>
                         <tr>

--- a/pages/CalendarPage.tsx
+++ b/pages/CalendarPage.tsx
@@ -3,13 +3,17 @@ import YearlyCalendarView from '../components/YearlyCalendarView';
 import NavaCalendar from '../components/NavaCalendar';
 import { calendarEventsData } from '../data/calendarEvents';
 
-const ToggleButton: React.FC<{ label: string; isActive: boolean; onClick: () => void; }> = ({ label, isActive, onClick }) => (
+const ToggleButton: React.FC<{
+    label: string;
+    isActive: boolean;
+    onClick: () => void;
+}> = ({ label, isActive, onClick }) => (
     <button
         onClick={onClick}
-        className={`px-4 py-2 text-sm font-semibold rounded-md transition-colors ${
+        className={`px-4 py-2 text-sm font-semibold rounded-full transition-all duration-200 ${
             isActive
-                ? 'bg-brand-secondary text-white shadow'
-                : 'bg-white text-text-muted hover:bg-slate-100'
+                ? 'bg-brand-secondary text-white shadow-glow-sm'
+                : 'bg-transparent text-text-muted hover:bg-slate-100'
         }`}
     >
         {label}
@@ -20,16 +24,25 @@ const CalendarPage: React.FC = () => {
     const [viewMode, setViewMode] = useState<'monthly' | 'yearly'>('yearly');
 
     return (
-        <div className="bg-bg-panel border border-slate-200 rounded-lg shadow-sm h-full overflow-hidden flex flex-col">
-            <header className="flex-shrink-0 flex justify-end items-center p-3 gap-4 border-b border-slate-200">
-                <div className="flex items-center gap-2 bg-slate-100 p-1 rounded-lg">
-                    <ToggleButton label="Monthly" isActive={viewMode === 'monthly'} onClick={() => setViewMode('monthly')} />
-                    <ToggleButton label="Yearly" isActive={viewMode === 'yearly'} onClick={() => setViewMode('yearly')} />
+        <div className="bg-gradient-to-br from-bg-panel to-bg-panel-hover border border-slate-200 rounded-xl shadow-md h-full overflow-hidden flex flex-col">
+            <header className="flex-shrink-0 flex justify-between items-center px-6 py-4 bg-white/70 backdrop-blur-sm border-b border-slate-200">
+                <h1 className="text-2xl font-bold text-text-primary">Academic Calendar</h1>
+                <div className="flex items-center gap-2 bg-white p-1 rounded-full shadow-inner">
+                    <ToggleButton
+                        label="Monthly"
+                        isActive={viewMode === 'monthly'}
+                        onClick={() => setViewMode('monthly')}
+                    />
+                    <ToggleButton
+                        label="Yearly"
+                        isActive={viewMode === 'yearly'}
+                        onClick={() => setViewMode('yearly')}
+                    />
                 </div>
             </header>
-            <div className="flex-grow min-h-0">
+            <div className="flex-grow min-h-0 bg-bg-panel">
                 {viewMode === 'yearly' ? (
-                     <YearlyCalendarView events={calendarEventsData} />
+                    <YearlyCalendarView events={calendarEventsData} />
                 ) : (
                     <NavaCalendar events={calendarEventsData} />
                 )}


### PR DESCRIPTION
## Summary
- polish calendar view toggle buttons and container styling
- refresh Nava and Yearly calendar headers for a softer look

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895f2a92ccc832393bf4fe7c5ffaba7